### PR TITLE
Ft/recursive subcategories

### DIFF
--- a/__test__/pages/api/barcode-symbology/[id].test.ts
+++ b/__test__/pages/api/barcode-symbology/[id].test.ts
@@ -1,12 +1,13 @@
 import HttpMocks from "node-mocks-http";
-import { IProductBrand, generateRandomString, seedMockBarcodeSymbologies } from "@/utils";
+import { generateRandomString, seedMockBarcodeSymbologies } from "@/utils";
 import barcodeSymbologyApi from "@/pages/api/barcode-symbology/[id]";
 import prismaClient from "@/utils/prisma-client";
+import { BarcodeSymbology } from "@prisma/client";
 
 describe("tests api/barcode-symbology/id route", () => {
     let req: any;
     let res: any;
-    let barcodeSymbology: IProductBrand;
+    let barcodeSymbology: BarcodeSymbology;
     let barcodeSymbologyId: string;
 
     beforeEach(() => {
@@ -16,7 +17,7 @@ describe("tests api/barcode-symbology/id route", () => {
 
     beforeAll(async () => {
         // Mock data
-        barcodeSymbology = await seedMockBarcodeSymbologies(1) as IProductBrand;
+        barcodeSymbology = (await seedMockBarcodeSymbologies(1))[0];
         barcodeSymbologyId = (await prismaClient.barcodeSymbology.findUnique({ where: { name: barcodeSymbology.name } }))?.id as string;
     })
 
@@ -68,14 +69,14 @@ describe("tests api/barcode-symbology/id route", () => {
         await barcodeSymbologyApi(req, res);
         expect(res.statusCode).toBe(200);
         expect(res.statusMessage).toBe("OK");
-        const olderVersion = await prismaClient.barcodeSymbology.findUnique({ where: { id: barcodeSymbologyId } }) as IProductBrand;
+        const olderVersion = await prismaClient.barcodeSymbology.findUnique({ where: { id: barcodeSymbologyId } });
         expect({
             id: barcodeSymbologyId,
             name: barcodeSymbology.name,
             isActive: true,
             createdAt: olderVersion?.createdAt, 
             updatedAt: olderVersion?.updatedAt,
-        }).toMatchObject(olderVersion);
+        }).toEqual(olderVersion);
     })
 
     it("ignore extra fields not in barcode-symbology model", async() => {
@@ -86,7 +87,7 @@ describe("tests api/barcode-symbology/id route", () => {
         expect(res.statusCode).toBe(400);
         expect(res.statusMessage).toBe("Bad Request");
         expect(res._getData()).toEqual("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
-        const olderVersion = await prismaClient.barcodeSymbology.findUnique({ where: { id: barcodeSymbologyId } }) as IProductBrand;
+        const olderVersion = await prismaClient.barcodeSymbology.findUnique({ where: { id: barcodeSymbologyId } });
         expect({
             id: barcodeSymbologyId,
             name: barcodeSymbology.name,

--- a/__test__/pages/api/barcode-symbology/index.test.ts
+++ b/__test__/pages/api/barcode-symbology/index.test.ts
@@ -1,12 +1,13 @@
 import HttpMocks from "node-mocks-http";
-import { IProductBrand, seedMockBarcodeSymbologies } from "@/utils";
+import { seedMockBarcodeSymbologies } from "@/utils";
 import barcodeSymbologyApi from "@/pages/api/barcode-symbology";
 import prismaClient from "@/utils/prisma-client";
+import { BarcodeSymbology } from "@prisma/client";
 
 describe("tests api/barcode-symbology/index route", () => {
     let req: any;
     let res: any;
-    let barcodes: IProductBrand[];
+    let barcodes: BarcodeSymbology[];
 
     beforeEach(() => {
         req = HttpMocks.createRequest();
@@ -15,7 +16,7 @@ describe("tests api/barcode-symbology/index route", () => {
 
     beforeAll(async () => {
         // Mock data
-        barcodes = await seedMockBarcodeSymbologies(3) as IProductBrand[];
+        barcodes = await seedMockBarcodeSymbologies(3);
     })
 
     afterAll(async () => {

--- a/__test__/pages/api/product-brand/[id].test.ts
+++ b/__test__/pages/api/product-brand/[id].test.ts
@@ -1,12 +1,13 @@
 import HttpMocks from "node-mocks-http";
-import { IProductBrand, generateRandomString, seedMockProductBrands } from "@/utils";
+import { generateRandomString, seedMockProductBrands } from "@/utils";
 import productBrandApi from "@/pages/api/product-brand/[id]";
 import prismaClient from "@/utils/prisma-client";
+import { ProductBrand } from "@prisma/client";
 
 describe("tests api/product-brand/id route", () => {
     let req: any;
     let res: any;
-    let productBrand: IProductBrand;
+    let productBrand: ProductBrand;
     let productBrandId: string;
 
     beforeEach(() => {
@@ -16,7 +17,7 @@ describe("tests api/product-brand/id route", () => {
 
     beforeAll(async () => {
         // Mock data
-        productBrand = await seedMockProductBrands(1) as IProductBrand;
+        productBrand = (await seedMockProductBrands(1))[0];
         productBrandId = (await prismaClient.productBrand.findUnique({ where: { name: productBrand.name } }))?.id as string;
     })
 
@@ -68,14 +69,14 @@ describe("tests api/product-brand/id route", () => {
         await productBrandApi(req, res);
         expect(res.statusCode).toBe(200);
         expect(res.statusMessage).toBe("OK");
-        const olderVersion = await prismaClient.productBrand.findUnique({ where: { id: productBrandId } }) as IProductBrand;
+        const olderVersion = await prismaClient.productBrand.findUnique({ where: { id: productBrandId } });
         expect({
             id: productBrandId,
             name: productBrand.name,
             isActive: true,
             createdAt: olderVersion?.createdAt, 
             updatedAt: olderVersion?.updatedAt,
-        }).toMatchObject(olderVersion);
+        }).toEqual(olderVersion);
     })
 
     it("ignore extra fields not in product-brand model", async() => {
@@ -86,7 +87,7 @@ describe("tests api/product-brand/id route", () => {
         expect(res.statusCode).toBe(400);
         expect(res.statusMessage).toBe("Bad Request");
         expect(res._getData()).toEqual("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
-        const olderVersion = await prismaClient.productBrand.findUnique({ where: { id: productBrandId } }) as IProductBrand;
+        const olderVersion = await prismaClient.productBrand.findUnique({ where: { id: productBrandId } });
         expect({
             id: productBrandId,
             name: productBrand.name,

--- a/__test__/pages/api/product-brand/index.test.ts
+++ b/__test__/pages/api/product-brand/index.test.ts
@@ -1,12 +1,13 @@
 import HttpMocks from "node-mocks-http";
-import { IProductBrand, seedMockProductBrands } from "@/utils";
+import { seedMockProductBrands } from "@/utils";
 import productBrandApi from "@/pages/api/product-brand";
 import prismaClient from "@/utils/prisma-client";
+import { ProductBrand } from "@prisma/client";
 
 describe("tests api/product-brand/index route", () => {
     let req: any;
     let res: any;
-    let brands: IProductBrand[];
+    let brands: ProductBrand[];
 
     beforeEach(() => {
         req = HttpMocks.createRequest();
@@ -15,7 +16,7 @@ describe("tests api/product-brand/index route", () => {
 
     beforeAll(async () => {
         // Mock data
-        brands = await seedMockProductBrands(3) as IProductBrand[];
+        brands = await seedMockProductBrands(3);
     })
 
     afterAll(async () => {

--- a/__test__/pages/api/product-category/[id].test.ts
+++ b/__test__/pages/api/product-category/[id].test.ts
@@ -1,14 +1,13 @@
 import HttpMocks from "node-mocks-http";
-import { generateRandomString, seedMockProductTypes } from "@/utils";
-import productTypeApi from "@/pages/api/product-type/[id]";
+import { generateRandomString, seedMockProductCategories } from "@/utils";
+import productCategoryApi from "@/pages/api/product-category/[id]";
 import prismaClient from "@/utils/prisma-client";
-import { ProductType } from "@prisma/client";
+import { ProductCategory } from "@prisma/client";
 
-describe("tests api/product-type/id route", () => {
+describe("tests api/product-category/id route", () => {
     let req: any;
     let res: any;
-    let productType: ProductType;
-    let productTypeId: string;
+    let productCategory: ProductCategory;
 
     beforeEach(() => {
         req = HttpMocks.createRequest();
@@ -17,123 +16,165 @@ describe("tests api/product-type/id route", () => {
 
     beforeAll(async () => {
         // Mock data
-        productType = (await seedMockProductTypes())[0];
-        productTypeId = (await prismaClient.productType.findUnique({ where: { name: productType.name } }))?.id as string;
+        productCategory = (await seedMockProductCategories(1))[0];
     })
 
     afterAll(async () => {
         // Clear DB
-        await prismaClient.productType.deleteMany();
+        await prismaClient.productCategory.deleteMany();
     })
 
     it("only accepts GET, PUT or DELETE requests", async() => {
         req.method = "POST";
         req.query = { id: "efb3b969-6225-440c-9f82-1bf7877b9d96" };
-        await productTypeApi(req, res);
+        await productCategoryApi(req, res);
         expect(res.statusCode).toBe(405);
         expect(res.statusMessage).toEqual("Method Not Allowed");
         expect(res.getHeader("Allow")).toEqual("GET, PUT, DELETE");
     })
 
-    it("returns 400 if product-type ID is not in route", async() => {
+    it("returns 400 if product-category ID is not in route", async() => {
         req.method = "GET";
-        await productTypeApi(req, res);
+        await productCategoryApi(req, res);
         expect(res.statusCode).toBe(400);
         expect(res.statusMessage).toEqual("Bad Request");
     })
 
-    it("returns 404 if GET product-type is not found", async() => {
+    it("returns 404 if GET product-category is not found", async() => {
         req.method = "GET";
         req.query = { id: "efb3b969-6225-440c-9f82-1bf7877b9d96" };
-        await productTypeApi(req, res);
+        await productCategoryApi(req, res);
         expect(res.statusCode).toBe(404);
         expect(res.statusMessage).toEqual("Not Found");
     })
 
-    it("fetches product-type by Id", async() => {
+    it("fetches product-category by Id", async() => {
         req.method = "GET";
-        req.query = { id: productTypeId };
-        await productTypeApi(req, res);
+        req.query = { id: productCategory.id };
+        await productCategoryApi(req, res);
         expect(res.statusCode).toBe(200);
         expect(res.statusMessage).toEqual("OK");
         expect(res._getJSONData()).toBeDefined();
         expect(res._getJSONData()).toMatchObject({ 
-            name: productType.name,
+            name: productCategory.name,
         });
     })
 
-    it("does not update product-type if req.body has fields missing from product-type model", async () => {
+    it("does not update product-category if req.body is empty", async () => {
         req.method = "PUT";
-        req.query = { id: productTypeId };
+        req.query = { id: productCategory.id };
         req.body = {};
-        await productTypeApi(req, res);
+        await productCategoryApi(req, res);
         expect(res.statusCode).toBe(200);
         expect(res.statusMessage).toBe("OK");
-        const olderVersion = await prismaClient.productType.findUnique({ where: { id: productTypeId } });
-        expect({
-            id: productTypeId,
-            name: productType.name,
-            isActive: true,
-            createdAt: olderVersion?.createdAt, 
-            updatedAt: olderVersion?.updatedAt,
-        }).toEqual(olderVersion);
+        const olderVersion = await prismaClient.productCategory.findUnique({ where: { id: productCategory.id } });
+        expect({ ...productCategory }).toEqual(olderVersion);
     })
 
-    it("ignore extra fields not in product-type model", async() => {
+    it("ignore extra fields not in product-category model", async() => {
         req.method = "PUT";
-        req.query = { id: productTypeId };
+        req.query = { id: productCategory.id };
         req.body = { field: "test" };
-        await productTypeApi(req, res);
+        await productCategoryApi(req, res);
         expect(res.statusCode).toBe(400);
         expect(res.statusMessage).toBe("Bad Request");
         expect(res._getData()).toEqual("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
-        const olderVersion = await prismaClient.productType.findUnique({ where: { id: productTypeId } });
+        const olderVersion = await prismaClient.productCategory.findUnique({ where: { id: productCategory.id } });
         expect({
-            id: productTypeId,
-            name: productType.name,
-            isActive: true,
-            createdAt: olderVersion?.createdAt, 
-            updatedAt: olderVersion?.updatedAt,
+            ...productCategory
         }).toEqual(olderVersion);
     })
 
-    it("updates a product-type", async() => {
+    it("updates a product-category", async() => {
         req.method = "PUT";
-        req.query = { id: productTypeId };
+        req.query = { id: productCategory.id };
         let changes = {
             name: generateRandomString(),
         };
         req.body = { ...changes };
-        await productTypeApi(req, res);
+        await productCategoryApi(req, res);
         
         expect(res.statusCode).toBe(200);
         expect(res.statusMessage).toEqual("OK");
         
-        const newType = await prismaClient.productType.findUnique({ where: { name: changes.name } });
+        const updatedCategory = await prismaClient.productCategory.findUnique({ where: { name: changes.name } });
 
-        expect(newType).toBeDefined();
-        expect({ ...changes }).toEqual({ 
-            name: newType?.name,
-        });
+        expect(updatedCategory).toBeDefined();
+        expect({  ...productCategory, ...changes, updatedAt: updatedCategory?.updatedAt }).toEqual({ ...updatedCategory });
     })
 
     it("returns 404 if no product to delete", async() => {
         req.method = "DELETE";
         req.query = { id: "a295438e-58a6-4fa7-8cc1-70af34a3b8c0" }
 
-        await productTypeApi(req, res);
+        await productCategoryApi(req, res);
         expect(res.statusCode).toBe(404);
         expect(res.statusMessage).toBe("Not Found");
     })
 
     it("deletes a product", async() => {
         req.method = "DELETE";
-        req.query = { id: productTypeId }
+        req.query = { id: productCategory.id }
 
-        await productTypeApi(req, res);
-        const result = await prismaClient.productType.findUnique({ where: { id: productTypeId } });
+        await productCategoryApi(req, res);
+        const result = await prismaClient.productCategory.findUnique({ where: { id: productCategory.id } });
         expect(res.statusCode).toBe(200);
         expect(res.statusMessage).toBe("OK");
         expect(result?.isActive).toBe(false);
     })
+})
+
+describe("tests recursive subcategories", () => {
+    let categories: ProductCategory[] = [];
+    let req: any;
+    let res: any;
+
+    beforeAll(async () => {
+        // Generate parent
+        let parent = (await seedMockProductCategories())[0];
+        categories.push(parent);
+        // Generate sub-categories
+        let children = await seedMockProductCategories(3, parent.id);
+        children.forEach(el => categories.push(el));
+
+        // Generate sub-sub-categories
+        let grandChildren = await seedMockProductCategories(2, children[0].id);
+        grandChildren.forEach(el => categories.push(el));
+    });
+
+    afterAll(async () => {
+        await prismaClient.productCategory.deleteMany();
+    });
+
+    beforeEach(() => {
+        req = HttpMocks.createRequest();
+        res = HttpMocks.createResponse();
+    })
+
+    it("fetches a category and its sub categories", async() => {
+        const categoryId = categories[0].id;
+        req.method = "GET";
+        req.query = { id: categoryId };
+        await productCategoryApi(req, res);
+        let json = res._getJSONData();
+        expect(json.id).toEqual(categoryId);
+        expect(json.breadcrumbs).toHaveLength(0); // Parent category has no breadcrumbs
+        expect(json.subCategories).toHaveLength(3);
+        expect(json.subCategories[0].parentCategoryId).toEqual(categoryId);
+        expect(json.subCategories[1].parentCategoryId).toEqual(categoryId);
+        expect(json.subCategories[2].parentCategoryId).toEqual(categoryId);
+    })
+
+    it("fetches a product subcategory and its ancestor's names", async() => {
+        let child = categories.at(-1);
+        req.method = "GET";
+        req.query = { id: child?.id };
+        await productCategoryApi(req, res);
+        let json = res._getJSONData();
+        expect(json.id).toEqual(child?.id);
+        expect(json.subCategories).toHaveLength(0);
+        expect(json.breadcrumbs).toHaveLength(2);
+        expect(json.breadcrumbs[0]).toEqual(categories[0].name);
+        expect(json.breadcrumbs[1]).toEqual(categories[1].name);
+    });
 })

--- a/__test__/pages/api/product-category/[id].test.ts
+++ b/__test__/pages/api/product-category/[id].test.ts
@@ -1,12 +1,13 @@
 import HttpMocks from "node-mocks-http";
-import { IProductType, generateRandomString, seedMockProductTypes } from "@/utils";
+import { generateRandomString, seedMockProductTypes } from "@/utils";
 import productTypeApi from "@/pages/api/product-type/[id]";
 import prismaClient from "@/utils/prisma-client";
+import { ProductType } from "@prisma/client";
 
 describe("tests api/product-type/id route", () => {
     let req: any;
     let res: any;
-    let productType: IProductType;
+    let productType: ProductType;
     let productTypeId: string;
 
     beforeEach(() => {
@@ -16,7 +17,7 @@ describe("tests api/product-type/id route", () => {
 
     beforeAll(async () => {
         // Mock data
-        productType = await seedMockProductTypes(1) as IProductType;
+        productType = (await seedMockProductTypes())[0];
         productTypeId = (await prismaClient.productType.findUnique({ where: { name: productType.name } }))?.id as string;
     })
 
@@ -68,14 +69,14 @@ describe("tests api/product-type/id route", () => {
         await productTypeApi(req, res);
         expect(res.statusCode).toBe(200);
         expect(res.statusMessage).toBe("OK");
-        const olderVersion = await prismaClient.productType.findUnique({ where: { id: productTypeId } }) as IProductType;
+        const olderVersion = await prismaClient.productType.findUnique({ where: { id: productTypeId } });
         expect({
             id: productTypeId,
             name: productType.name,
             isActive: true,
             createdAt: olderVersion?.createdAt, 
             updatedAt: olderVersion?.updatedAt,
-        }).toMatchObject(olderVersion);
+        }).toEqual(olderVersion);
     })
 
     it("ignore extra fields not in product-type model", async() => {
@@ -86,7 +87,7 @@ describe("tests api/product-type/id route", () => {
         expect(res.statusCode).toBe(400);
         expect(res.statusMessage).toBe("Bad Request");
         expect(res._getData()).toEqual("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
-        const olderVersion = await prismaClient.productType.findUnique({ where: { id: productTypeId } }) as IProductType;
+        const olderVersion = await prismaClient.productType.findUnique({ where: { id: productTypeId } });
         expect({
             id: productTypeId,
             name: productType.name,

--- a/__test__/pages/api/product-category/index.test.ts
+++ b/__test__/pages/api/product-category/index.test.ts
@@ -2,6 +2,7 @@ import HttpMocks from "node-mocks-http";
 import { IProductCategory, seedMockProductCategories } from "@/utils";
 import productCategoryApi from "@/pages/api/product-category";
 import prismaClient from "@/utils/prisma-client";
+import { ProductCategory } from "@prisma/client";
 
 describe("tests api/product-category/index route", () => {
     let req: any;
@@ -72,5 +73,61 @@ describe("tests api/product-category/index route if table is empty", () => {
         expect(res.statusMessage).toEqual("OK");
         expect(res._getJSONData()).toBeDefined();
         expect(res._getJSONData()).toHaveLength(0);
+    })
+})
+
+describe("tests recursive subcategories", () => {
+    let categories: IProductCategory[] = [];
+
+    beforeAll(async () => {
+        // Generate parent
+        let parent = await seedMockProductCategories() as IProductCategory;
+        categories.push(parent);
+        // Generate sub-categories
+        let children = await seedMockProductCategories(3, parent.id) as IProductCategory[];
+
+        // Generate sub-sub-categories
+        let grandChildren = await seedMockProductCategories(2, children[0].id) as IProductCategory[];
+        grandChildren.forEach(el => categories.push(el));
+    });
+
+    afterAll(async () => {
+        await prismaClient.productCategory.deleteMany();
+    });
+
+    it("fetches a category and its sub categories", async() => {
+        let result = await prismaClient.productCategory.findFirst({
+            where: {
+                id: categories[0].id
+            },
+            include: {
+                subCategories: true
+            }
+        });
+
+        expect(result?.subCategories).toHaveLength(3);
+    })
+
+    it("gets ancestry tree given child category id", async() => {
+        let child = categories.at(-1);
+
+        const result = await prismaClient.$queryRaw<ProductCategory[]>`
+            WITH RECURSIVE subcategories AS (
+                SELECT id, name, code, description, parent_category AS "parentCategoryId"
+                FROM product_category 
+                WHERE id = ${child?.id} 
+                UNION 
+                SELECT p.id, p.name, p.code, p.description, p.parent_category AS "parentCategoryId"
+                FROM product_category p 
+                INNER JOIN subcategories s 
+                ON s."parentCategoryId" = p.id
+            )
+            SELECT * FROM subcategories
+        `;
+
+        expect(result).toHaveLength(3);
+        expect(result[0].parentCategoryId).toEqual(result[1].id);
+        expect(result[1].parentCategoryId).toEqual(result[2].id);
+        expect(result[2].parentCategoryId).toBeNull();
     })
 })

--- a/__test__/pages/api/product-category/index.test.ts
+++ b/__test__/pages/api/product-category/index.test.ts
@@ -1,5 +1,5 @@
 import HttpMocks from "node-mocks-http";
-import { IProductCategory, seedMockProductCategories } from "@/utils";
+import { seedMockProductCategories } from "@/utils";
 import productCategoryApi from "@/pages/api/product-category";
 import prismaClient from "@/utils/prisma-client";
 import { ProductCategory } from "@prisma/client";
@@ -7,7 +7,7 @@ import { ProductCategory } from "@prisma/client";
 describe("tests api/product-category/index route", () => {
     let req: any;
     let res: any;
-    let categories: IProductCategory[];
+    let categories: ProductCategory[];
 
     beforeEach(() => {
         req = HttpMocks.createRequest();
@@ -16,7 +16,7 @@ describe("tests api/product-category/index route", () => {
 
     beforeAll(async () => {
         // Mock data
-        categories = await seedMockProductCategories(3) as IProductCategory[];
+        categories = await seedMockProductCategories(3);
     })
 
     afterAll(async () => {
@@ -77,17 +77,17 @@ describe("tests api/product-category/index route if table is empty", () => {
 })
 
 describe("tests recursive subcategories", () => {
-    let categories: IProductCategory[] = [];
+    let categories: ProductCategory[] = [];
 
     beforeAll(async () => {
         // Generate parent
-        let parent = await seedMockProductCategories() as IProductCategory;
+        let parent = (await seedMockProductCategories())[0];
         categories.push(parent);
         // Generate sub-categories
-        let children = await seedMockProductCategories(3, parent.id) as IProductCategory[];
+        let children = await seedMockProductCategories(3, parent.id);
 
         // Generate sub-sub-categories
-        let grandChildren = await seedMockProductCategories(2, children[0].id) as IProductCategory[];
+        let grandChildren = await seedMockProductCategories(2, children[0].id);
         grandChildren.forEach(el => categories.push(el));
     });
 

--- a/__test__/pages/api/product-type/[id].test.ts
+++ b/__test__/pages/api/product-type/[id].test.ts
@@ -1,13 +1,14 @@
 import HttpMocks from "node-mocks-http";
-import { generateRandomString, seedMockProductCategories } from "@/utils";
-import productCategoryApi from "@/pages/api/product-category/[id]";
+import { generateRandomString, seedMockProductTypes } from "@/utils";
+import productTypeApi from "@/pages/api/product-type/[id]";
 import prismaClient from "@/utils/prisma-client";
-import { ProductCategory } from "@prisma/client";
+import { ProductType } from "@prisma/client";
 
-describe("tests api/product-category/id route", () => {
+describe("tests api/product-type/id route", () => {
     let req: any;
     let res: any;
-    let productCategory: ProductCategory;
+    let productType: ProductType;
+    let productTypeId: string;
 
     beforeEach(() => {
         req = HttpMocks.createRequest();
@@ -16,108 +17,121 @@ describe("tests api/product-category/id route", () => {
 
     beforeAll(async () => {
         // Mock data
-        productCategory = (await seedMockProductCategories(1))[0];
+        productType = (await seedMockProductTypes())[0];
+        productTypeId = (await prismaClient.productType.findUnique({ where: { name: productType.name } }))?.id as string;
     })
 
     afterAll(async () => {
         // Clear DB
-        await prismaClient.productCategory.deleteMany();
+        await prismaClient.productType.deleteMany();
     })
 
     it("only accepts GET, PUT or DELETE requests", async() => {
         req.method = "POST";
         req.query = { id: "efb3b969-6225-440c-9f82-1bf7877b9d96" };
-        await productCategoryApi(req, res);
+        await productTypeApi(req, res);
         expect(res.statusCode).toBe(405);
         expect(res.statusMessage).toEqual("Method Not Allowed");
         expect(res.getHeader("Allow")).toEqual("GET, PUT, DELETE");
     })
 
-    it("returns 400 if product-category ID is not in route", async() => {
+    it("returns 400 if product-type ID is not in route", async() => {
         req.method = "GET";
-        await productCategoryApi(req, res);
+        await productTypeApi(req, res);
         expect(res.statusCode).toBe(400);
         expect(res.statusMessage).toEqual("Bad Request");
     })
 
-    it("returns 404 if GET product-category is not found", async() => {
+    it("returns 404 if GET product-type is not found", async() => {
         req.method = "GET";
         req.query = { id: "efb3b969-6225-440c-9f82-1bf7877b9d96" };
-        await productCategoryApi(req, res);
+        await productTypeApi(req, res);
         expect(res.statusCode).toBe(404);
         expect(res.statusMessage).toEqual("Not Found");
     })
 
-    it("fetches product-category by Id", async() => {
+    it("fetches product-type by Id", async() => {
         req.method = "GET";
-        req.query = { id: productCategory.id };
-        await productCategoryApi(req, res);
+        req.query = { id: productTypeId };
+        await productTypeApi(req, res);
         expect(res.statusCode).toBe(200);
         expect(res.statusMessage).toEqual("OK");
         expect(res._getJSONData()).toBeDefined();
         expect(res._getJSONData()).toMatchObject({ 
-            name: productCategory.name,
+            name: productType.name,
         });
     })
 
-    it("does not update product-category if req.body is empty", async () => {
+    it("does not update product-type if req.body has fields missing from product-type model", async () => {
         req.method = "PUT";
-        req.query = { id: productCategory.id };
+        req.query = { id: productTypeId };
         req.body = {};
-        await productCategoryApi(req, res);
+        await productTypeApi(req, res);
         expect(res.statusCode).toBe(200);
         expect(res.statusMessage).toBe("OK");
-        const olderVersion = await prismaClient.productCategory.findUnique({ where: { id: productCategory.id } });
-        expect({ ...productCategory }).toEqual(olderVersion);
-    })
-
-    it("ignore extra fields not in product-category model", async() => {
-        req.method = "PUT";
-        req.query = { id: productCategory.id };
-        req.body = { field: "test" };
-        await productCategoryApi(req, res);
-        expect(res.statusCode).toBe(400);
-        expect(res.statusMessage).toBe("Bad Request");
-        expect(res._getData()).toEqual("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
-        const olderVersion = await prismaClient.productCategory.findUnique({ where: { id: productCategory.id } });
+        const olderVersion = await prismaClient.productType.findUnique({ where: { id: productTypeId } });
         expect({
-            ...productCategory
+            id: productTypeId,
+            name: productType.name,
+            isActive: true,
+            createdAt: olderVersion?.createdAt, 
+            updatedAt: olderVersion?.updatedAt,
         }).toEqual(olderVersion);
     })
 
-    it("updates a product-category", async() => {
+    it("ignore extra fields not in product-type model", async() => {
         req.method = "PUT";
-        req.query = { id: productCategory.id };
+        req.query = { id: productTypeId };
+        req.body = { field: "test" };
+        await productTypeApi(req, res);
+        expect(res.statusCode).toBe(400);
+        expect(res.statusMessage).toBe("Bad Request");
+        expect(res._getData()).toEqual("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
+        const olderVersion = await prismaClient.productType.findUnique({ where: { id: productTypeId } });
+        expect({
+            id: productTypeId,
+            name: productType.name,
+            isActive: true,
+            createdAt: olderVersion?.createdAt, 
+            updatedAt: olderVersion?.updatedAt,
+        }).toEqual(olderVersion);
+    })
+
+    it("updates a product-type", async() => {
+        req.method = "PUT";
+        req.query = { id: productTypeId };
         let changes = {
             name: generateRandomString(),
         };
         req.body = { ...changes };
-        await productCategoryApi(req, res);
+        await productTypeApi(req, res);
         
         expect(res.statusCode).toBe(200);
         expect(res.statusMessage).toEqual("OK");
         
-        const updatedCategory = await prismaClient.productCategory.findUnique({ where: { name: changes.name } });
+        const newType = await prismaClient.productType.findUnique({ where: { name: changes.name } });
 
-        expect(updatedCategory).toBeDefined();
-        expect({  ...productCategory, ...changes, updatedAt: updatedCategory?.updatedAt }).toEqual({ ...updatedCategory });
+        expect(newType).toBeDefined();
+        expect({ ...changes }).toEqual({ 
+            name: newType?.name,
+        });
     })
 
     it("returns 404 if no product to delete", async() => {
         req.method = "DELETE";
         req.query = { id: "a295438e-58a6-4fa7-8cc1-70af34a3b8c0" }
 
-        await productCategoryApi(req, res);
+        await productTypeApi(req, res);
         expect(res.statusCode).toBe(404);
         expect(res.statusMessage).toBe("Not Found");
     })
 
     it("deletes a product", async() => {
         req.method = "DELETE";
-        req.query = { id: productCategory.id }
+        req.query = { id: productTypeId }
 
-        await productCategoryApi(req, res);
-        const result = await prismaClient.productCategory.findUnique({ where: { id: productCategory.id } });
+        await productTypeApi(req, res);
+        const result = await prismaClient.productType.findUnique({ where: { id: productTypeId } });
         expect(res.statusCode).toBe(200);
         expect(res.statusMessage).toBe("OK");
         expect(result?.isActive).toBe(false);

--- a/__test__/pages/api/product-type/index.test.ts
+++ b/__test__/pages/api/product-type/index.test.ts
@@ -1,12 +1,13 @@
 import HttpMocks from "node-mocks-http";
-import { IProductType, seedMockProductTypes } from "@/utils";
+import { seedMockProductTypes } from "@/utils";
 import productTypeApi from "@/pages/api/product-type";
 import prismaClient from "@/utils/prisma-client";
+import { ProductType } from "@prisma/client";
 
 describe("tests api/product-type/index route", () => {
     let req: any;
     let res: any;
-    let types: IProductType[];
+    let types: ProductType[];
 
     beforeEach(() => {
         req = HttpMocks.createRequest();
@@ -15,7 +16,7 @@ describe("tests api/product-type/index route", () => {
 
     beforeAll(async () => {
         // Mock data
-        types = await seedMockProductTypes(3) as IProductType[];
+        types = await seedMockProductTypes(3);
     })
 
     afterAll(async () => {

--- a/__test__/pages/api/product/[id].test.ts
+++ b/__test__/pages/api/product/[id].test.ts
@@ -1,12 +1,13 @@
 import HttpMocks from "node-mocks-http";
-import { IProduct, cleanUpMockProducts, generateRandomString, seedMockProducts } from "@/utils";
+import { cleanUpMockProducts, generateRandomString, seedMockProducts } from "@/utils";
 import productApi from "@/pages/api/product/[id]";
 import prismaClient from "@/utils/prisma-client";
+import { Product } from "@prisma/client";
 
 describe("tests api/product/id route", () => {
     let req: any;
     let res: any;
-    let product: IProduct;
+    let product: Product;
     let productId: string;
 
     beforeEach(() => {
@@ -16,7 +17,7 @@ describe("tests api/product/id route", () => {
 
     beforeAll(async () => {
         // Mock data
-        product = await seedMockProducts(1) as IProduct;
+        product = (await seedMockProducts(1))[0];
         productId = (await prismaClient.product.findUnique({ where: { code: product.code } }))?.id as string;
     })
 

--- a/__test__/pages/api/product/[id].test.ts
+++ b/__test__/pages/api/product/[id].test.ts
@@ -70,7 +70,8 @@ describe("tests api/product/id route", () => {
             unitOfMeasure: { name: "Pieces" },
             productCategory: { name: "CategoryA" },
             productBrand: { name: "Super" },
-            barcodeSymbology: { name: "UPC-A" }
+            barcodeSymbology: { name: "UPC-A" },
+            breadcrumbs: []
         });
     })
 

--- a/__test__/pages/api/product/add.test.ts
+++ b/__test__/pages/api/product/add.test.ts
@@ -1,7 +1,7 @@
 import prismaClient from "@/utils/prisma-client";
 import HttpMocks from "node-mocks-http";
 import addProductApi from "@/pages/api/product/add";
-import { IProduct, cleanUpMockProducts, seedMockProducts, seedProductForeignKeys } from "@/utils";
+import { cleanUpMockProducts, generateRandomString, seedMockProducts, seedProductForeignKeys } from "@/utils";
 
 describe("tests the api/product/add route", () => {
     let baseProduct: {[key: string]: any};
@@ -62,11 +62,14 @@ describe("tests the api/product/add route", () => {
     })
 
     it("fails to save product due to duplicate product code", async() => {
-        let products = await seedMockProducts(2) as IProduct[];
-        await prismaClient.product.create({ data: { ...products[0], code: "PROD-3" } });
-        products[1].code = "PROD-3";
+        let [ product ] = await seedMockProducts();
+        const duplicate = {
+            ...product,
+            id: undefined,
+            name: generateRandomString()
+        }
         req.method = "POST";
-        req.body = {...products[1] };
+        req.body = {...duplicate };
 
         await addProductApi(req, res);
         expect(res.statusCode).toBe(400);

--- a/__test__/pages/api/product/index.test.ts
+++ b/__test__/pages/api/product/index.test.ts
@@ -1,12 +1,13 @@
 import HttpMocks from "node-mocks-http";
-import { IProduct, cleanUpMockProducts, seedMockProducts } from "@/utils";
+import { cleanUpMockProducts, seedMockProducts } from "@/utils";
 import getProductsApi from "@/pages/api/product";
 import prismaClient from "@/utils/prisma-client";
+import { Product } from "@prisma/client";
 
 describe("tests api/product/api route", () => {
     let req: any;
     let res: any;
-    let products: IProduct[];
+    let products: Product[];
 
     beforeEach(() => {
         req = HttpMocks.createRequest();
@@ -15,7 +16,7 @@ describe("tests api/product/api route", () => {
 
     beforeAll(async () => {
         // Mock data
-        products = await seedMockProducts(3) as IProduct[];
+        products = await seedMockProducts(3);
     })
 
     afterAll(async () => {

--- a/__test__/pages/api/unit-of-measure/[id].test.ts
+++ b/__test__/pages/api/unit-of-measure/[id].test.ts
@@ -1,12 +1,13 @@
 import HttpMocks from "node-mocks-http";
-import { IUnitOfMeasure, generateRandomString, seedMockUnitOfMeasures } from "@/utils";
+import { generateRandomString, seedMockUnitOfMeasures } from "@/utils";
 import unitOfMeasureApi from "@/pages/api/unit-of-measure/[id]";
 import prismaClient from "@/utils/prisma-client";
+import { UnitOfMeasure } from "@prisma/client";
 
 describe("tests api/unit-of-measure/id route", () => {
     let req: any;
     let res: any;
-    let unitOfMeasure: IUnitOfMeasure;
+    let unitOfMeasure: UnitOfMeasure;
     let unitOfMeasureId: string;
 
     beforeEach(() => {
@@ -16,7 +17,7 @@ describe("tests api/unit-of-measure/id route", () => {
 
     beforeAll(async () => {
         // Mock data
-        unitOfMeasure = await seedMockUnitOfMeasures(1) as IUnitOfMeasure;
+        unitOfMeasure = (await seedMockUnitOfMeasures(1))[0];
         unitOfMeasureId = (await prismaClient.unitOfMeasure.findUnique({ where: { name: unitOfMeasure.name } }))?.id as string;
     })
 
@@ -68,14 +69,14 @@ describe("tests api/unit-of-measure/id route", () => {
         await unitOfMeasureApi(req, res);
         expect(res.statusCode).toBe(200);
         expect(res.statusMessage).toBe("OK");
-        const olderVersion = await prismaClient.unitOfMeasure.findUnique({ where: { id: unitOfMeasureId } }) as IUnitOfMeasure;
+        const olderVersion = await prismaClient.unitOfMeasure.findUnique({ where: { id: unitOfMeasureId } });
         expect({
             id: unitOfMeasureId,
             name: unitOfMeasure.name,
             isActive: true,
             createdAt: olderVersion?.createdAt, 
             updatedAt: olderVersion?.updatedAt,
-        }).toMatchObject(olderVersion);
+        }).toEqual(olderVersion);
     })
 
     it("ignore extra fields not in unit-of-measure model", async() => {
@@ -86,7 +87,7 @@ describe("tests api/unit-of-measure/id route", () => {
         expect(res.statusCode).toBe(400);
         expect(res.statusMessage).toBe("Bad Request");
         expect(res._getData()).toEqual("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
-        const olderVersion = await prismaClient.unitOfMeasure.findUnique({ where: { id: unitOfMeasureId } }) as IUnitOfMeasure;
+        const olderVersion = await prismaClient.unitOfMeasure.findUnique({ where: { id: unitOfMeasureId } });
         expect({
             id: unitOfMeasureId,
             name: unitOfMeasure.name,

--- a/__test__/pages/api/unit-of-measure/index.test.ts
+++ b/__test__/pages/api/unit-of-measure/index.test.ts
@@ -1,12 +1,13 @@
 import HttpMocks from "node-mocks-http";
-import { IUnitOfMeasure, seedMockUnitOfMeasures } from "@/utils";
+import { seedMockUnitOfMeasures } from "@/utils";
 import unitOfMeasureApi from "@/pages/api/unit-of-measure";
 import prismaClient from "@/utils/prisma-client";
+import { UnitOfMeasure } from "@prisma/client";
 
 describe("tests api/unit-of-measure/index route", () => {
     let req: any;
     let res: any;
-    let unitOfMeasure: IUnitOfMeasure[];
+    let unitOfMeasure: UnitOfMeasure[];
 
     beforeEach(() => {
         req = HttpMocks.createRequest();
@@ -15,7 +16,7 @@ describe("tests api/unit-of-measure/index route", () => {
 
     beforeAll(async () => {
         // Mock data
-        unitOfMeasure = await seedMockUnitOfMeasures(3) as IUnitOfMeasure[];
+        unitOfMeasure = await seedMockUnitOfMeasures(3);
     })
 
     afterAll(async () => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest -t \"tests recursive subcategories\" --detectOpenHandles",
+    "test": "jest --detectOpenHandles",
     "migrate:dev": "prisma migrate dev",
     "postinstall": "prisma generate"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --detectOpenHandles",
+    "test": "jest -t \"tests recursive subcategories\" --detectOpenHandles",
     "migrate:dev": "prisma migrate dev",
     "postinstall": "prisma generate"
   },

--- a/pages/api/product-category/[id].ts
+++ b/pages/api/product-category/[id].ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth";
 import { authOptions } from "../auth/[...nextauth]";
-import { statusMessages } from "@/utils";
+import { getProductCategoryBreadcrumb, statusMessages } from "@/utils";
 import prismaClient from "@/utils/prisma-client";
 import { Prisma } from "@prisma/client";
 
@@ -19,10 +19,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             const result = await prismaClient.productCategory.findUnique({
                 where: {
                     id: req.query.id as string
+                },
+                include: {
+                    subCategories: true
                 }
             });
             if (!result) return res.writeHead(404, statusMessages[404]).end();
-            return res.status(200).json(result);
+            let breadcrumbs = await getProductCategoryBreadcrumb(result.id);
+            return res.status(200).json({ ...result, breadcrumbs });
         case "PUT":
             try {
                 await prismaClient.productCategory.update({

--- a/pages/api/product-category/add.ts
+++ b/pages/api/product-category/add.ts
@@ -14,11 +14,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     switch(req.method) {
         case "POST":
             try {
-                await prismaClient.productCategory.create({
+                const result = await prismaClient.productCategory.create({
                     data: { ...req.body }
                 });
     
-                return res.writeHead(201, statusMessages[201]).end();
+                return res.writeHead(201, statusMessages[201]).json(result);
             } catch(e) {
                 if(e instanceof Prisma.PrismaClientValidationError) {
                     // Missing required fields are missing. See https://www.prisma.io/docs/reference/api-reference/error-reference#prismaclientvalidationerror

--- a/pages/api/product-category/index.ts
+++ b/pages/api/product-category/index.ts
@@ -14,7 +14,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             // Get all items. See https://www.prisma.io/docs/concepts/components/prisma-client/crud#get-all-records
             const result = await prismaClient.productCategory.findMany({
                 where: {
-                    isActive: req.query.isActive === "false" ? false : true
+                    isActive: req.query.isActive === "false" ? false : true,
+                    parentCategoryId: null // Only OG categories i.e. no parents
                 }
             });
             return res.status(200).json(result);

--- a/pages/api/product/[id].ts
+++ b/pages/api/product/[id].ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth";
 import { authOptions } from "../auth/[...nextauth]";
-import { statusMessages } from "@/utils";
+import { getProductCategoryBreadcrumb, statusMessages } from "@/utils";
 import prismaClient from "@/utils/prisma-client";
 import { Prisma } from "@prisma/client";
 
@@ -31,11 +31,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     productCategory: { select: { name: true } },
                     unitOfMeasure: { select: { name: true } },
                     productType: { select: { name: true } },
-                    barcodeSymbology: { select: { name: true } }
+                    barcodeSymbology: { select: { name: true } },
+                    productCategoryId: true
                 }
             });
             if (!result) return res.writeHead(404, statusMessages[404]).end();
-            return res.status(200).json(result);
+            const breadcrumbs = await getProductCategoryBreadcrumb(result.productCategoryId);
+            let { productCategoryId, ...rest } = result;
+            return res.status(200).json({ ...rest, breadcrumbs });
         case "PUT":
             try {
                 await prismaClient.product.update({

--- a/prisma/migrations/20230710211532_infinitely_nested_categories_schema/migration.sql
+++ b/prisma/migrations/20230710211532_infinitely_nested_categories_schema/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[code]` on the table `product_category` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `code` to the `product_category` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "product_category" ADD COLUMN     "code" STRING NOT NULL;
+ALTER TABLE "product_category" ADD COLUMN     "description" STRING;
+ALTER TABLE "product_category" ADD COLUMN     "parent_category" UUID;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "product_category_code_key" ON "product_category"("code");
+
+-- AddForeignKey
+ALTER TABLE "product_category" ADD CONSTRAINT "product_category_parent_category_fkey" FOREIGN KEY ("parent_category") REFERENCES "product_category"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,9 +69,14 @@ model ProductBrand {
 
 model ProductCategory {
   id String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  code String @unique
   name String @unique
+  description String?
   isActive Boolean @default(true)
-  // Prisma relation fields. Don't get created in db. See https://www.prisma.io/docs/concepts/components/prisma-schema/relations
+  // Recursive parent-child categories relationship. See https://www.prisma.io/docs/concepts/components/prisma-schema/relations/self-relations
+  subCategories ProductCategory[] @relation("ParentChildCategories")
+  parentCategory ProductCategory? @relation("ParentChildCategories", fields: [parentCategoryId], references: [id])
+  parentCategoryId String? @db.Uuid @map("parent_category")
   products Product[]
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/utils/functions.ts
+++ b/utils/functions.ts
@@ -1,4 +1,6 @@
 import bcrypt from "bcrypt";
+import prismaClient from "./prisma-client";
+import { ProductCategory } from "@prisma/client";
 
 export function generateRandomString(length: number = 8): string {
     let chars: string = "0123456789abcdefghijklmnopqrstuvwxyz@#&ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -20,4 +22,28 @@ export async function hashPassword(password: string | undefined, saltRounds: num
 export async function comparePassword(password: string | undefined, hash: string): Promise<boolean> {
     if (!password) return false;
     return bcrypt.compare(password, hash);
+}
+
+export async function getProductCategoryBreadcrumb(categoryId: String): Promise<String[]> {
+    const result = await prismaClient.$queryRaw<ProductCategory[]>`
+        WITH RECURSIVE subcategories AS (
+            SELECT id, name, parent_category AS "parentCategoryId"
+            FROM product_category 
+            WHERE id = ${categoryId} 
+            UNION 
+            SELECT p.id, p.name, p.parent_category AS "parentCategoryId"
+            FROM product_category p 
+            INNER JOIN subcategories s 
+            ON s."parentCategoryId" = p.id
+        )
+        SELECT * FROM subcategories WHERE id <> ${categoryId};
+    `;
+
+    let breadcrumbs: String[] = [];
+
+    for (let i = result.length - 1; i >= 0; --i) {
+        breadcrumbs.push(result[i].name);
+    }
+
+    return breadcrumbs;
 }

--- a/utils/mock-data.ts
+++ b/utils/mock-data.ts
@@ -1,6 +1,7 @@
 import { generateRandomString } from "./functions";
 import prismaClient from "./prisma-client";
-import { IBarcodeSymbology, IProduct, IProductBrand, IProductCategory, IProductRelationships, IProductType, IUnitOfMeasure } from "./types";
+import { ProductCategory, ProductType, ProductBrand, BarcodeSymbology, Product, UnitOfMeasure } from "@prisma/client";
+import { IProductRelationships } from "./types";
 
 export const mockUser = {
     firstname: "jane",
@@ -45,31 +46,29 @@ export async function seedProductForeignKeys(): Promise<IProductRelationships> {
  * @param qty number of products to create. Defaults to 1
  * @returns product(s) that were created and saved in the DB
  */
-export async function seedMockProducts(qty: number = 1): Promise<IProduct | IProduct[]> {
+export async function seedMockProducts(qty: number = 1): Promise<Product[]> {
     if (process.env.NODE_ENV !== "test") throw new Error("Illegal function call");
     
     let baseProduct = { ...(await seedProductForeignKeys()) };
-    let products = [];
 
-    for(let i = 0; i < qty; i++) {
-        products.push({
-            name: generateRandomString(),
-            code: generateRandomString(12),
-            cost: i * 5,
-            price: i * 5,
-            quantity: i * 5,
-            alertQuantity: i * 5,
-            isActive: true,
-            details: null,
-            images: [],
-            ...baseProduct
-        });
-    }
+    let result = await prismaClient.$transaction(
+        [...Array(qty)].map((_, i) => prismaClient.product.create({ 
+            data: {
+                name: generateRandomString(),
+                code: generateRandomString(12),
+                cost: i * 5,
+                price: i * 5,
+                quantity: i * 5,
+                alertQuantity: i * 5,
+                isActive: true,
+                details: null,
+                images: [],
+                ...baseProduct
+            }
+        }))
+    );
 
-    await prismaClient.product.createMany({ data: products });
-
-    if(qty == 1) return products[0];
-    return products;
+    return result;
 }
 
 /**
@@ -86,38 +85,46 @@ export async function cleanUpMockProducts() {
     await prismaClient.barcodeSymbology.deleteMany();
 }
 
-export async function seedMockProductBrands(qty: number = 1): Promise<IProductBrand | IProductBrand[]> {
+export async function seedMockProductBrands(qty: number = 1): Promise<ProductBrand[]> {
     if (process.env.NODE_ENV !== "test") throw new Error("Illegal function call");
-    let list = [];
-    for(let i = 0; i < qty; i++) list.push({ name: generateRandomString(6) });
-    await prismaClient.productBrand.createMany({ data: list });
-    if(qty == 1) return list[0] ?? [];
-    return list;
-}
-
-export async function seedMockUnitOfMeasures(qty: number = 1): Promise<IUnitOfMeasure | IUnitOfMeasure[]> {
-    if (process.env.NODE_ENV !== "test") throw new Error("Illegal function call");
-    let list = [];
-    for(let i = 0; i < qty; i++) list.push({ name: generateRandomString(6) });
-    await prismaClient.unitOfMeasure.createMany({ data: list });
-    if(qty == 1) return list[0] ?? [];
-    return list;
-}
-
-export async function seedMockProductTypes(qty: number = 1): Promise<IProductType | IProductType[]> {
-    if (process.env.NODE_ENV !== "test") throw new Error("Illegal function call");
-    let list = [];
-    for(let i = 0; i < qty; i++) list.push({ name: generateRandomString(6) });
-    await prismaClient.productType.createMany({ data: list });
-    if(qty == 1) return list[0] ?? [];
-    return list;
-}
-
-export async function seedMockProductCategories(qty: number = 1, parentId: string | null = null): Promise<IProductCategory | IProductCategory[]> {
-    if (process.env.NODE_ENV !== "test") throw new Error("Illegal function call");
-
     let result = await prismaClient.$transaction(
-        [...Array(qty)].map((category) => prismaClient.productCategory.create({ 
+        [...Array(qty)].map((_) => prismaClient.productBrand.create({ 
+            data: {
+                name: generateRandomString(6),
+            }
+        }))
+    );
+    return result;
+}
+
+export async function seedMockUnitOfMeasures(qty: number = 1): Promise<UnitOfMeasure[]> {
+    if (process.env.NODE_ENV !== "test") throw new Error("Illegal function call");
+    let result = await prismaClient.$transaction(
+        [...Array(qty)].map((_) => prismaClient.unitOfMeasure.create({ 
+            data: {
+                name: generateRandomString(6),
+            }
+        }))
+    );
+    return result;
+}
+
+export async function seedMockProductTypes(qty: number = 1): Promise<ProductType[]> {
+    if (process.env.NODE_ENV !== "test") throw new Error("Illegal function call");
+    let result = await prismaClient.$transaction(
+        [...Array(qty)].map((_) => prismaClient.productType.create({ 
+            data: {
+                name: generateRandomString(6),
+            }
+        }))
+    );
+    return result;
+}
+
+export async function seedMockProductCategories(qty: number = 1, parentId: string | null = null): Promise<ProductCategory[]> {
+    if (process.env.NODE_ENV !== "test") throw new Error("Illegal function call");
+    let result = await prismaClient.$transaction(
+        [...Array(qty)].map((_) => prismaClient.productCategory.create({ 
             data: {
                 name: generateRandomString(6),
                 code: generateRandomString(6),
@@ -125,16 +132,17 @@ export async function seedMockProductCategories(qty: number = 1, parentId: strin
             }
         }))
     );
-
-    if(qty == 1) return result[0] ?? [];
     return result;
 }
 
-export async function seedMockBarcodeSymbologies(qty: number = 1): Promise<IBarcodeSymbology | IBarcodeSymbology[]> {
+export async function seedMockBarcodeSymbologies(qty: number = 1): Promise<BarcodeSymbology[]> {
     if (process.env.NODE_ENV !== "test") throw new Error("Illegal function call");
-    let list = [];
-    for(let i = 0; i < qty; i++) list.push({ name: generateRandomString(6) });
-    await prismaClient.barcodeSymbology.createMany({ data: list });
-    if(qty == 1) return list[0] ?? [];
-    return list;
+    let result = await prismaClient.$transaction(
+        [...Array(qty)].map((_) => prismaClient.barcodeSymbology.create({ 
+            data: {
+                name: generateRandomString(6),
+            }
+        }))
+    );
+    return result;
 }

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -3,48 +3,10 @@ export enum Roles {
     USER
 }
 
-interface IBaseModel {
-    id?: string;
-    createdAt?: Date,
-    updatedAt?: Date
-}
-
 export interface IProductRelationships {
     productTypeId: string;
     unitOfMeasureId: string;
     productBrandId: string;
     productCategoryId: string;
     barcodeSymbologyId: string;
-}
-
-export interface IProduct extends IProductRelationships, IBaseModel {
-    name: string;
-    code: string;
-    cost: number;
-    price: number;
-    quantity: number;
-    alertQuantity: number;
-    details?: string | null;
-    images?: string[];
-    isActive: boolean
-}
-
-export interface IProductBrand extends IBaseModel {
-    name: string
-}
-
-export interface IProductCategory extends IBaseModel {
-    name: string
-}
-
-export interface IUnitOfMeasure extends IBaseModel {
-    name: string
-}
-
-export interface IProductType extends IBaseModel {
-    name: string
-}
-
-export interface IBarcodeSymbology extends IBaseModel {
-    name: string
 }


### PR DESCRIPTION
Added the following features:

- When fetching products, include its breadcrumbs i.e. n-level categories
- When fetching a specific category, include its subcategories for display
- When fetching a sub-category, include its ancestors' names
- Fetching all categories in the index route fetches those at the root i.e. no parents