### PR TITLE
Save types n units, replaced res.send with end

### DIFF
--- a/components/settings/types/AddType.tsx
+++ b/components/settings/types/AddType.tsx
@@ -32,8 +32,18 @@ export default function AddType({
     defaultValues: defaultValues,
   });
 
-  const onSubmit = (data: FormInput) => {
-    console.log(data);
+  const onSubmit = async (data: FormInput) => {
+    const options = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    }
+  
+    const response = await fetch("/api/product-type/add", options);
+
+    const result = await response.json();
     reset();
   };
 
@@ -56,19 +66,19 @@ export default function AddType({
               are required input fields.
             </p>
           </DialogContentText>
-          <label htmlFor="typeName">
+          <label htmlFor="name">
             <span className="text-primaryDark font-semibold">Type Name</span>
             <span className="text-redColor"> *</span>
           </label>
-          <FormInputText name="typeName" control={control} label="Type Name" />
-          <label htmlFor="typeDescription">
+          <FormInputText name="name" control={control} label="Type Name" />
+          <label htmlFor="description">
             <span className="text-primaryDark font-semibold">
               Type Description
             </span>
             <span className="text-redColor"> *</span>
           </label>
           <FormInputText
-            name="typeDescription"
+            name="description"
             control={control}
             label="Type Description"
           />

--- a/components/settings/units/AddUnit.tsx
+++ b/components/settings/units/AddUnit.tsx
@@ -33,8 +33,18 @@ export default function AddUnit({
     defaultValues: defaultValues,
   });
 
-  const onSubmit = (data: FormInput) => {
-    console.log(data);
+  const onSubmit = async (data: FormInput) => {
+    const options = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    }
+  
+    const response = await fetch("/api/unit-of-measure/add", options);
+
+    const result = await response.json();
     reset();
   };
 

--- a/pages/api/barcode-symbology/[id].ts
+++ b/pages/api/barcode-symbology/[id].ts
@@ -39,7 +39,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     // User tried to send a key in JSON but the key is not in the DB model e.g
                     // { fieldA: "valueA" } will fail because the ProductModel does not have a
                     // field called fieldA
-                    return res.writeHead(400, statusMessages[400]).send("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
+                    return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
                 }
                 return res.status(500).end();
             }
@@ -58,7 +58,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 if(e instanceof Prisma.PrismaClientKnownRequestError) {
                     // Error thrown if item to be deleted is not found
                     // See https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
-                    if(e.code === "P2025") return res.writeHead(404, statusMessages[404]);
+                    if(e.code === "P2025") return res.writeHead(404, statusMessages[404]).end();
                 }
                 return res.status(500).end();
             }

--- a/pages/api/barcode-symbology/add.ts
+++ b/pages/api/barcode-symbology/add.ts
@@ -22,12 +22,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             } catch(e) {
                 if(e instanceof Prisma.PrismaClientValidationError) {
                     // Missing required fields are missing. See https://www.prisma.io/docs/reference/api-reference/error-reference#prismaclientvalidationerror
-                    return res.writeHead(400, statusMessages[400]).send("Some required fields are missing. Please check the data sent and try again");
+                    return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end("Some required fields are missing. Please check the data sent and try again");
                 } else if(e instanceof Prisma.PrismaClientKnownRequestError) {
                     // Unique constraint failed. See https://www.prisma.io/docs/reference/api-reference/error-reference#p2002
                     if(e.code === "P2002") {
                         let lines = e.message.split("\n");
-                        return res.writeHead(400, statusMessages[400]).send(lines.at(-1));
+                        return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end(lines.at(-1));
                     }
                 }
                 return res.status(500).end();

--- a/pages/api/product-brand/[id].ts
+++ b/pages/api/product-brand/[id].ts
@@ -39,7 +39,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     // User tried to send a key in JSON but the key is not in the DB model e.g
                     // { fieldA: "valueA" } will fail because the ProductModel does not have a
                     // field called fieldA
-                    return res.writeHead(400, statusMessages[400]).send("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
+                    return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
                 }
                 return res.status(500).end();
             }
@@ -58,7 +58,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 if(e instanceof Prisma.PrismaClientKnownRequestError) {
                     // Error thrown if item to be deleted is not found
                     // See https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
-                    if(e.code === "P2025") return res.writeHead(404, statusMessages[404]);
+                    if(e.code === "P2025") return res.writeHead(404, statusMessages[404]).end();
                 }
                 return res.status(500).end();
             }

--- a/pages/api/product-brand/add.ts
+++ b/pages/api/product-brand/add.ts
@@ -22,12 +22,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             } catch(e) {
                 if(e instanceof Prisma.PrismaClientValidationError) {
                     // Missing required fields are missing. See https://www.prisma.io/docs/reference/api-reference/error-reference#prismaclientvalidationerror
-                    return res.writeHead(400, statusMessages[400]).send("Some required fields are missing. Please check the data sent and try again");
+                    return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end("Some required fields are missing. Please check the data sent and try again");
                 } else if(e instanceof Prisma.PrismaClientKnownRequestError) {
                     // Unique constraint failed. See https://www.prisma.io/docs/reference/api-reference/error-reference#p2002
                     if(e.code === "P2002") {
                         let lines = e.message.split("\n");
-                        return res.writeHead(400, statusMessages[400]).send(lines.at(-1));
+                        return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end(lines.at(-1));
                     }
                 }
                 return res.status(500).end();

--- a/pages/api/product-category/[id].ts
+++ b/pages/api/product-category/[id].ts
@@ -43,7 +43,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     // User tried to send a key in JSON but the key is not in the DB model e.g
                     // { fieldA: "valueA" } will fail because the ProductModel does not have a
                     // field called fieldA
-                    return res.writeHead(400, statusMessages[400]).send("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
+                    return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
                 }
                 return res.status(500).end();
             }
@@ -62,7 +62,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 if(e instanceof Prisma.PrismaClientKnownRequestError) {
                     // Error thrown if item to be deleted is not found
                     // See https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
-                    if(e.code === "P2025") return res.writeHead(404, statusMessages[404]);
+                    if(e.code === "P2025") return res.writeHead(404, statusMessages[404]).end();
                 }
                 return res.status(500).end();
             }

--- a/pages/api/product-category/add.ts
+++ b/pages/api/product-category/add.ts
@@ -23,12 +23,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             } catch(e) {
                 if(e instanceof Prisma.PrismaClientValidationError) {
                     // Missing required fields are missing. See https://www.prisma.io/docs/reference/api-reference/error-reference#prismaclientvalidationerror
-                    return res.writeHead(400, statusMessages[400]).send("Some required fields are missing. Please check the data sent and try again");
+                    return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end("Some required fields are missing. Please check the data sent and try again");
                 } else if(e instanceof Prisma.PrismaClientKnownRequestError) {
                     // Unique constraint failed. See https://www.prisma.io/docs/reference/api-reference/error-reference#p2002
                     if(e.code === "P2002") {
                         let lines = e.message.split("\n");
-                        return res.writeHead(400, statusMessages[400]).send(lines.at(-1));
+                        return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end(lines.at(-1));
                     }
                 }
                 return res.status(500).end();

--- a/pages/api/product-type/[id].ts
+++ b/pages/api/product-type/[id].ts
@@ -39,7 +39,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     // User tried to send a key in JSON but the key is not in the DB model e.g
                     // { fieldA: "valueA" } will fail because the ProductModel does not have a
                     // field called fieldA
-                    return res.writeHead(400, statusMessages[400]).send("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
+                    return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
                 }
                 return res.status(500).end();
             }
@@ -58,7 +58,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 if(e instanceof Prisma.PrismaClientKnownRequestError) {
                     // Error thrown if item to be deleted is not found
                     // See https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
-                    if(e.code === "P2025") return res.writeHead(404, statusMessages[404]);
+                    if(e.code === "P2025") return res.writeHead(404, statusMessages[404]).end();
                 }
                 return res.status(500).end();
             }

--- a/pages/api/product-type/add.ts
+++ b/pages/api/product-type/add.ts
@@ -23,12 +23,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             } catch(e) {
                 if(e instanceof Prisma.PrismaClientValidationError) {
                     // Missing required fields are missing. See https://www.prisma.io/docs/reference/api-reference/error-reference#prismaclientvalidationerror
-                    return res.writeHead(400, statusMessages[400]).send("Some required fields are missing. Please check the data sent and try again");
+                    return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end("Some required fields are missing. Please check the data sent and try again");
                 } else if(e instanceof Prisma.PrismaClientKnownRequestError) {
                     // Unique constraint failed. See https://www.prisma.io/docs/reference/api-reference/error-reference#p2002
                     if(e.code === "P2002") {
                         let lines = e.message.split("\n");
-                        return res.writeHead(400, statusMessages[400]).send(lines.at(-1));
+                        return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end(lines.at(-1));
                     }
                 }
                 return res.status(500).end();

--- a/pages/api/product/[id].ts
+++ b/pages/api/product/[id].ts
@@ -55,10 +55,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     // User tried to send a key in JSON but the key is not in the DB model e.g
                     // { fieldA: "valueA" } will fail because the ProductModel does not have a
                     // field called fieldA
-                    return res.writeHead(400, statusMessages[400]).send("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
+                    return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
                 } else if(e instanceof Prisma.PrismaClientKnownRequestError) {
                     if(e.code === "P2003") {
-                        return res.writeHead(400, statusMessages[400]).send("Invalid dependent item");
+                        return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end("Invalid dependent item");
                     }
                 }
                 return res.status(500).end();
@@ -78,7 +78,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 if(e instanceof Prisma.PrismaClientKnownRequestError) {
                     // Error thrown if item to be deleted is not found
                     // See https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
-                    if(e.code === "P2025") return res.writeHead(404, statusMessages[404]);
+                    if(e.code === "P2025") return res.writeHead(404, statusMessages[404]).end();
                 }
                 return res.status(500).end();
             }

--- a/pages/api/product/add.ts
+++ b/pages/api/product/add.ts
@@ -30,15 +30,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             } catch(e) {
                 if(e instanceof Prisma.PrismaClientValidationError) {
                     // Missing required fields are missing. See https://www.prisma.io/docs/reference/api-reference/error-reference#prismaclientvalidationerror
-                    return res.writeHead(400, statusMessages[400]).send("Some required fields are missing. Please check the data sent and try again");
+                    return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end("Some required fields are missing. Please check the data sent and try again");
                 } else if(e instanceof Prisma.PrismaClientKnownRequestError) {
                     // Unique constraint failed. See https://www.prisma.io/docs/reference/api-reference/error-reference#p2002
                     if(e.code === "P2002") {
                         let lines = e.message.split("\n");
-                        return res.writeHead(400, statusMessages[400]).send(lines.at(-1));
+                        return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end(lines.at(-1));
                     } else if(e.code === "P2003") {
                         // Provided foreign key not in DB. See https://www.prisma.io/docs/reference/api-reference/error-reference#p2002
-                        return res.writeHead(400, statusMessages[400]).send("Invalid dependent item");
+                        return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end("Invalid dependent item");
                     }
                 }
                 return res.status(500).end();

--- a/pages/api/unit-of-measure/[id].ts
+++ b/pages/api/unit-of-measure/[id].ts
@@ -39,7 +39,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     // User tried to send a key in JSON but the key is not in the DB model e.g
                     // { fieldA: "valueA" } will fail because the ProductModel does not have a
                     // field called fieldA
-                    return res.writeHead(400, statusMessages[400]).send("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
+                    return res.writeHead(400, statusMessages[400], { "Content-Type": "text/plain" }).end("Invalid key found in the JSON object sent. Please refer to the spec and try again!");
                 }
                 return res.status(500).end();
             }
@@ -58,7 +58,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 if(e instanceof Prisma.PrismaClientKnownRequestError) {
                     // Error thrown if item to be deleted is not found
                     // See https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
-                    if(e.code === "P2025") return res.writeHead(404, statusMessages[404]);
+                    if(e.code === "P2025") return res.writeHead(404, statusMessages[404]).end();
                 }
                 return res.status(500).end();
             }

--- a/pages/api/unit-of-measure/add.ts
+++ b/pages/api/unit-of-measure/add.ts
@@ -23,14 +23,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             } catch(e) {
                 if(e instanceof Prisma.PrismaClientValidationError) {
                     // Missing required fields are missing. See https://www.prisma.io/docs/reference/api-reference/error-reference#prismaclientvalidationerror
-                    return res.writeHead(400, statusMessages[400]).send("Some required fields are missing. Please check the data sent and try again");
+                    return res
+                        .writeHead(400, statusMessages[400], { "Content-Type": "text/plain" })
+                        .end("Some required fields are missing. Please check the data sent and try again");
                 } else if(e instanceof Prisma.PrismaClientKnownRequestError) {
                     // Unique constraint failed. See https://www.prisma.io/docs/reference/api-reference/error-reference#p2002
                     if(e.code === "P2002") {
                         let lines = e.message.split("\n");
-                        return res.writeHead(400, statusMessages[400]).send(lines.at(-1));
+                        return res
+                            .writeHead(400, statusMessages[400], { "Content-Type": "text/plain" })
+                            .end(lines.at(-1));
                     }
-                }
+                } 
                 return res.status(500).end();
             }
         default:


### PR DESCRIPTION
Changed the following:
- Persist measurement units and product types in DB. 
- Replaced res.send with res.end wherever res.writeHead was used. This was to fix the error: `[ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client`. 
- Added res.end to areas where it was missing so as to ensure the response is sent